### PR TITLE
Add translation memory cache

### DIFF
--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -32,7 +32,8 @@ class ConfigManager:
             "max_concurrent_tasks": 3,
             "auto_review_mode": True,
             "delayed_review": True,
-            "key_rotation_strategy": "round_robin"
+            "key_rotation_strategy": "round_robin",
+            "use_translation_memory": True
         }
         self.config = self.load_config()
         self._migrate_legacy_api_key()

--- a/core/translation_workflow.py
+++ b/core/translation_workflow.py
@@ -11,6 +11,7 @@ from typing import List, Dict, Optional, Callable, Any, Tuple
 from config.config_manager import ConfigManager
 from parsers.yml_parser import YMLParser
 from utils.file_utils import FileProcessor
+from utils.translation_memory import TranslationMemory
 from .parallel_translator import ParallelTranslator
 
 
@@ -30,7 +31,15 @@ class TranslationWorkflow:
         self.yml_parser = YMLParser()
         self.file_processor = FileProcessor(self.yml_parser)
         self.parallel_translator = ParallelTranslator(app_ref, config_manager)
-        
+
+        self.use_translation_memory = self.config_manager.get_setting(
+            "use_translation_memory", True
+        )
+        memory_file = os.path.join(
+            os.path.dirname(config_manager.config_file_path), "translation_memory.json"
+        )
+        self.translation_memory = TranslationMemory(memory_file)
+
         # 工作流程状态
         self.is_running = False
         self.stop_flag = threading.Event()
@@ -134,7 +143,10 @@ class TranslationWorkflow:
                 return False
             
             # 等待翻译完成并收集结果
-            translation_results = self._collect_translation_results(total_entries)
+            translation_results = self._collect_translation_results(
+                total_entries,
+                self.cached_results
+            )
             
             # 停止并行翻译器
             self.parallel_translator.stop_workers()
@@ -147,6 +159,17 @@ class TranslationWorkflow:
             success = self._generate_translated_files(
                 filtered_files, translation_results, target_lang
             )
+
+            if self.use_translation_memory:
+                for res in translation_results.values():
+                    if res.get('translated_text'):
+                        self.translation_memory.add(
+                            res['original_text'],
+                            res['translated_text'],
+                            source_lang,
+                            target_lang
+                        )
+                self.translation_memory.save()
             
             self.app_ref.log_message(
                 f"翻译工作流程完成：处理了 {len(translation_results)} 个条目", 
@@ -179,6 +202,7 @@ class TranslationWorkflow:
     ) -> int:
         """添加翻译任务"""
         total_entries = 0
+        self.cached_results: Dict[str, Dict] = {}
         
         for file_path in file_paths:
             if self.stop_flag.is_set():
@@ -190,9 +214,32 @@ class TranslationWorkflow:
                     continue
                 
                 for entry in entries:
-                    if entry['value'].strip():  # 只翻译非空值
+                    if not entry['value'].strip():
+                        continue
+
+                    entry_id = f"{file_path}:{entry['key']}"
+                    cached_text = None
+                    if self.use_translation_memory:
+                        cached_text = self.translation_memory.get(
+                            entry['value'], source_lang, target_lang
+                        )
+                    if cached_text:
+                        self.cached_results[entry_id] = {
+                            'entry_id': entry_id,
+                            'original_text': entry['value'],
+                            'translated_text': cached_text,
+                            'token_count': 0,
+                            'api_error_type': None,
+                            'original_line_content': entry.get('original_line_content'),
+                            'source_lang': source_lang
+                        }
+                        self.app_ref.log_message(
+                            f"缓存命中: {entry['key']} -> {cached_text[:30]}...",
+                            "debug"
+                        )
+                    else:
                         self.parallel_translator.add_translation_task(
-                            entry_id=f"{file_path}:{entry['key']}",
+                            entry_id=entry_id,
                             text=entry['value'],
                             source_lang=source_lang,
                             target_lang=target_lang,
@@ -200,7 +247,7 @@ class TranslationWorkflow:
                             model_name=model_name,
                             original_line_content=entry.get('original_line_content')
                         )
-                        total_entries += 1
+                    total_entries += 1
                 
                 self.app_ref.log_message(
                     f"已添加文件 {os.path.basename(file_path)} 的 {len(entries)} 个翻译任务", 
@@ -213,10 +260,18 @@ class TranslationWorkflow:
         
         return total_entries
     
-    def _collect_translation_results(self, total_entries: int) -> Dict[str, Dict]:
+    def _collect_translation_results(self, total_entries: int, initial_results: Optional[Dict[str, Dict]] = None) -> Dict[str, Dict]:
         """收集翻译结果"""
-        translation_results = {}
-        processed_entries = 0
+        translation_results = initial_results.copy() if initial_results else {}
+        processed_entries = len(translation_results)
+
+        if processed_entries and self.progress_callback:
+            self.progress_callback(processed_entries, total_entries)
+            progress = (processed_entries / total_entries) * 100
+            self.app_ref.log_message(
+                f"翻译进度: {processed_entries}/{total_entries} ({progress:.1f}%)",
+                "info",
+            )
 
         # 获取评审设置
         auto_review_mode = self.app_ref.config_manager.get_setting("auto_review_mode", True)

--- a/tests/test_translation_memory.py
+++ b/tests/test_translation_memory.py
@@ -1,0 +1,26 @@
+import unittest
+import tempfile
+import os
+from utils.translation_memory import TranslationMemory
+
+
+class TestTranslationMemory(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.tm_path = os.path.join(self.temp_dir.name, 'tm.json')
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_add_and_retrieve(self):
+        tm = TranslationMemory(self.tm_path)
+        tm.add('Hello', '你好', 'english', 'simp_chinese')
+        tm.save()
+
+        tm2 = TranslationMemory(self.tm_path)
+        result = tm2.get('Hello', 'english', 'simp_chinese')
+        self.assertEqual(result, '你好')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -7,5 +7,6 @@
 from .logging_utils import setup_logging, LogLevel
 from .validation import validate_api_key, validate_file_path, validate_language_code
 from .file_utils import FileProcessor
+from .translation_memory import TranslationMemory
 
-__all__ = ['setup_logging', 'LogLevel', 'validate_api_key', 'validate_file_path', 'validate_language_code', 'FileProcessor']
+__all__ = ['setup_logging', 'LogLevel', 'validate_api_key', 'validate_file_path', 'validate_language_code', 'FileProcessor', 'TranslationMemory']

--- a/utils/translation_memory.py
+++ b/utils/translation_memory.py
@@ -1,0 +1,38 @@
+import json
+import os
+from typing import Dict, Optional
+
+class TranslationMemory:
+    """Simple JSON-based translation memory."""
+
+    def __init__(self, memory_path: str):
+        self.memory_path = memory_path
+        self.memory: Dict[str, Dict[str, Dict[str, str]]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            if os.path.exists(self.memory_path):
+                with open(self.memory_path, 'r', encoding='utf-8') as f:
+                    self.memory = json.load(f)
+        except Exception:
+            self.memory = {}
+
+    def save(self) -> None:
+        try:
+            os.makedirs(os.path.dirname(self.memory_path), exist_ok=True)
+            with open(self.memory_path, 'w', encoding='utf-8') as f:
+                json.dump(self.memory, f, ensure_ascii=False, indent=2)
+        except Exception:
+            pass
+
+    def get(self, source_text: str, source_lang: str, target_lang: str) -> Optional[str]:
+        return (
+            self.memory
+            .get(source_lang, {})
+            .get(target_lang, {})
+            .get(source_text)
+        )
+
+    def add(self, source_text: str, translated_text: str, source_lang: str, target_lang: str) -> None:
+        self.memory.setdefault(source_lang, {}).setdefault(target_lang, {})[source_text] = translated_text


### PR DESCRIPTION
## Summary
- add config `use_translation_memory`
- implement `TranslationMemory` json cache
- integrate cache lookup and save in `TranslationWorkflow`
- export new utility and add tests

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68408d38ebe88323a0af5ff079eff7a1