### PR TITLE
Add configurable placeholder patterns

### DIFF
--- a/CONFIGURATION_GUIDE.md
+++ b/CONFIGURATION_GUIDE.md
@@ -91,7 +91,13 @@
     "auto_review_mode": true,
     "delayed_review": true,
     "game_mod_style": "Strategy game localization, formal and precise tone.",
-    "key_rotation_strategy": "round_robin"
+    "key_rotation_strategy": "round_robin",
+    "placeholder_patterns": [
+        "(\\$.*?\\$)",
+        "(\\[.*?\\])",
+        "(@\\w+!)",
+        "(#\\w+(?:;\\w+)*.*?#!|\\S*#!)"
+    ]
 }
 ```
 
@@ -130,6 +136,19 @@
 }
 ```
 - 适用于: 大量文件翻译，后期统一质检
+
+### 4. 自定义占位符模式
+```json
+{
+    "placeholder_patterns": [
+        "(\\$.*?\\$)",
+        "(\\[.*?\\])",
+        "(@\\w+!)",
+        "(\\{[^}]+\\})"
+    ]
+}
+```
+- 适用于: 需要额外占位符格式时
 
 ## 🔍 故障排除
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ python start.py
     "source_language": "english",
     "target_language": "simp_chinese",
     "max_concurrent_tasks": 3,
-    "api_call_delay": 3.0
+    "api_call_delay": 3.0,
+    "placeholder_patterns": [
+        "(\\$.*?\\$)",
+        "(\\[.*?\\])",
+        "(@\\w+!)",
+        "(#\\w+(?:;\\w+)*.*?#!|\\S*#!)"
+    ]
 }
 ```
 

--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -7,7 +7,7 @@
 import json
 import os
 from typing import Any, Dict, List, Optional
-from .constants import DEFAULT_API_KEY_PLACEHOLDER
+from .constants import DEFAULT_API_KEY_PLACEHOLDER, DEFAULT_PLACEHOLDER_PATTERNS
 
 
 class ConfigManager:
@@ -32,7 +32,8 @@ class ConfigManager:
             "max_concurrent_tasks": 3,
             "auto_review_mode": True,
             "delayed_review": True,
-            "key_rotation_strategy": "round_robin"
+            "key_rotation_strategy": "round_robin",
+            "placeholder_patterns": DEFAULT_PLACEHOLDER_PATTERNS
         }
         self.config = self.load_config()
         self._migrate_legacy_api_key()

--- a/config/constants.py
+++ b/config/constants.py
@@ -24,6 +24,12 @@ MODEL_RPM = {
 # 配置文件相关常量
 CONFIG_FILE = "translator_config.json"
 DEFAULT_API_KEY_PLACEHOLDER = "YOUR_GEMINI_API_KEY"
+DEFAULT_PLACEHOLDER_PATTERNS = [
+    r'(\$.*?\$)',
+    r'(\[.*?\])',
+    r'(@\w+!)',
+    r'(#\w+(?:;\w+)*.*?#!|\S*#!)'
+]
 
 # 支持的语言列表
 SUPPORTED_LANGUAGES = {

--- a/core/translation_workflow.py
+++ b/core/translation_workflow.py
@@ -27,7 +27,7 @@ class TranslationWorkflow:
         """
         self.app_ref = app_ref
         self.config_manager = config_manager
-        self.yml_parser = YMLParser()
+        self.yml_parser = YMLParser(config_manager=self.config_manager)
         self.file_processor = FileProcessor(self.yml_parser)
         self.parallel_translator = ParallelTranslator(app_ref, config_manager)
         

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ class ModTranslatorApp:
         self.logger = ApplicationLogger()
 
         # 初始化解析器
-        self.yml_parser = YMLParser()
+        self.yml_parser = YMLParser(config_manager=self.config_manager)
 
         # 初始化文件处理器
         self.file_processor = FileProcessor(self.yml_parser)

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -35,6 +35,12 @@ class TestConfigManager(unittest.TestCase):
         self.assertEqual(self.config_manager.get_setting("target_language"), "simp_chinese")
         self.assertEqual(self.config_manager.get_setting("max_concurrent_tasks"), 3)
         self.assertTrue(self.config_manager.get_setting("auto_review_mode"))
+
+    def test_placeholder_pattern_default(self):
+        """测试占位符正则默认配置"""
+        patterns = self.config_manager.get_setting("placeholder_patterns")
+        self.assertIsInstance(patterns, list)
+        self.assertIn(r'(\$.*?\$)', patterns)
     
     def test_save_and_load_config(self):
         """测试配置保存和加载"""

--- a/tests/test_yml_parser.py
+++ b/tests/test_yml_parser.py
@@ -185,6 +185,14 @@ class TestYMLParser(unittest.TestCase):
         numbered_entry = next((entry for entry in entries if entry['key'] == 'test_key_4'), None)
         self.assertIsNotNone(numbered_entry)
         self.assertEqual(numbered_entry['value'], "This is a numbered entry")
+
+    def test_custom_placeholder_patterns(self):
+        """测试自定义占位符正则"""
+        patterns = [r'\{[^}]+\}']
+        parser = YMLParser(placeholder_patterns=patterns)
+        text = "Hello {player}"
+        placeholders = parser.extract_placeholders(text, regexes=parser.placeholder_regexes)
+        self.assertIn("{player}", placeholders)
     
     def test_empty_file_handling(self):
         """测试空文件处理"""


### PR DESCRIPTION
## Summary
- extend `ConfigManager` with `placeholder_patterns` option
- load placeholder patterns in `YMLParser` from config or custom parameter
- document how to use `placeholder_patterns` in README and CONFIGURATION_GUIDE
- update main components to pass `ConfigManager` to `YMLParser`
- test new behaviour with unit tests

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68408d3b91fc83239e444c2e63878c57